### PR TITLE
Fix fetch_leave_history call in test

### DIFF
--- a/leavebot_copy/test_api_tools.py
+++ b/leavebot_copy/test_api_tools.py
@@ -56,7 +56,7 @@ except Exception as e:
 
 # 4. Test Leave History
 try:
-    history = fetch_leave_history(EMP_ID)
+    history = fetch_leave_history(EMP_ID, leave_types)
     pretty_print("Leave History", history)
 except Exception as e:
     print(f"[ERROR] Leave History: {e}")


### PR DESCRIPTION
## Summary
- update `test_api_tools` to pass `leave_types` into `fetch_leave_history`

## Testing
- `PYTHONPATH=. python leavebot_copy/test_api_tools.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684aa1e37a548323bdad1bc7c35128d8