### PR TITLE
Add basic project README

### DIFF
--- a/leavebot_copy/.env.example
+++ b/leavebot_copy/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to .env and fill in the actual values
+OPENAI_API_KEY=your-openai-api-key
+ERP_BEARER_TOKEN=your-erp-api-token
+EMPLOYEE_DETAILS_API=http://localhost/api/EmployeeMasterApi/HrmGetEmployeeDetails/
+LEAVE_TYPE_API=http://localhost/api/LeaveApplicationApi/FillLeaveType
+LEAVE_HISTORY_API=http://localhost/api/LeaveApplicationApi/HrmGetLeaveApplicationDetails
+LEAVE_SUMMARY_API=http://localhost/api/LeaveApplicationApi
+LOG_LEVEL=INFO
+LOG_FILE=leavebot.log
+OPENAI_MODEL=gpt-4o
+EMBEDDING_MODEL=text-embedding-3-large
+MAX_TOKENS=4096
+ENABLE_DOC_SEARCH=True
+ENABLE_API_FETCH=True

--- a/leavebot_copy/README.md
+++ b/leavebot_copy/README.md
@@ -1,0 +1,40 @@
+# LeaveBot Copy
+
+LeaveBot Copy is a proof‑of‑concept assistant that answers leave‑related questions for employees. It calls internal HR APIs to retrieve employee details, leave types, balances and history, and combines that data with OpenAI tools for conversational responses and policy search.
+
+## Installation
+
+1. Clone this repository and navigate into the project directory.
+2. Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configuration
+
+The application expects a `.env` file with API endpoints and secrets. A template is provided as `.env.example`.
+
+1. Copy the example file and edit it with your own values:
+
+```bash
+cp leavebot_copy/.env.example leavebot_copy/.env
+# then edit leavebot_copy/.env
+```
+
+2. Fill in your OpenAI API key and the URLs / tokens for the HR APIs.
+
+## Running the Batch Test
+
+You can run a scripted batch of questions using:
+
+```bash
+python -m leavebot_copy.scripts.test_chatbot_batch <emp_id>
+```
+
+Replace `<emp_id>` with the employee ID you want to test. The script resets the chatbot state for that employee, reads questions from `questions.txt`, and prints each question with the bot’s answer. Expect verbose debugging output that shows any tool calls made to fetch API data or search policy documents.
+
+## Dependencies
+
+The project relies on several internal API endpoints for employee data. These URLs and an authentication token (`ERP_BEARER_TOKEN`) must be supplied via environment variables. In addition, an `OPENAI_API_KEY` is required for both chat completion and embedding search features.
+


### PR DESCRIPTION
## Summary
- document LeaveBot setup instructions
- add a template `.env` file with placeholder values

## Testing
- `python -m leavebot_copy.scripts.test_chatbot_batch 432` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_684aa546d2248323a38a3a357d3be3e2