### PR TITLE
Add recent leave and air ticket tools

### DIFF
--- a/leavebot_copy/chatbot/chat_engine.py
+++ b/leavebot_copy/chatbot/chat_engine.py
@@ -7,7 +7,8 @@ from leavebot_copy.scripts.leave_utils import (
     leaves_by_type,
     available_leave_types,
     leave_type_balance,
-    is_on_leave_today
+    is_on_leave_today,
+    recent_leaves,
 )
 from leavebot_copy.scripts.employee_utils import (
     years_of_service,
@@ -19,6 +20,7 @@ from leavebot_copy.scripts.fetch_leave_types import fetch_leave_types
 from leavebot_copy.scripts.fetch_leave_balance import fetch_leave_balance
 from leavebot_copy.scripts.fetch_leave_history import fetch_leave_history  # now expects (emp_id, leave_types)
 from leavebot_copy.scripts.search_embeddings import search_embeddings  # RAG tool
+from leavebot_copy.scripts.air_ticket_utils import air_ticket_info
 
 
 # Setup OpenAI API key
@@ -79,6 +81,14 @@ def tool_is_on_leave_today(**kwargs):
     """Returns whether the employee is on leave today."""
     return is_on_leave_today(leave_history)
 
+def tool_recent_leaves(count=5, **kwargs):
+    """Returns the most recent leave applications."""
+    return recent_leaves(leave_history, count=count)
+
+def tool_air_ticket_info(**kwargs):
+    """Returns air ticket eligibility information."""
+    return air_ticket_info(leave_balances, leave_history)
+
 def tool_search_policy(question=None, **kwargs):
     """Search HR policy docs for answers to policy questions."""
     results = search_embeddings(question, top_k=2)
@@ -99,6 +109,8 @@ TOOL_MAP = {
     "employee_contact":    tool_employee_contact,
     "manager_contact":     tool_manager_contact,
     "is_on_leave_today":   tool_is_on_leave_today,
+    "recent_leaves":       tool_recent_leaves,
+    "air_ticket_info":     tool_air_ticket_info,
     "search_policy":       tool_search_policy,
 }
 
@@ -176,6 +188,27 @@ tools = [
         "function": {
             "name": "is_on_leave_today",
             "description": "Returns whether the employee is on leave today.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "recent_leaves",
+            "description": "Returns the most recent leave applications.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer", "description": "Number of records to return"}
+                }
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "air_ticket_info",
+            "description": "Returns air ticket eligibility information.",
             "parameters": {"type": "object", "properties": {}},
         },
     },

--- a/leavebot_copy/scripts/air_ticket_utils.py
+++ b/leavebot_copy/scripts/air_ticket_utils.py
@@ -37,4 +37,34 @@ def has_claimed_air_ticket(leave_history, year=None):
             return True
     return False
 
+
+def air_ticket_info(leave_balances, leave_history):
+    """Return eligibility details for employee air ticket."""
+    eligible_balance = None
+    for lb in leave_balances.values():
+        if is_air_ticket_eligible(lb):
+            eligible_balance = lb
+            break
+
+    if not eligible_balance:
+        return {"eligible": False}
+
+    percent = get_air_ticket_percent(eligible_balance)
+    anniv = eligible_balance.get("Emp_AnnivDate_D")
+
+    last_claim = None
+    for rec in leave_history:
+        if str(rec.get("Ela_AirTicketReq_N", "0")) == "1":
+            date = rec.get("LeaveGrid_dtTravelDate") or rec.get("LeaveGrid_Ela_FromDate_D")
+            if date and (not last_claim or date > last_claim):
+                last_claim = date
+
+    next_date = next_air_ticket_eligibility(anniv, last_claim) if anniv else None
+    return {
+        "eligible": True,
+        "percent": percent,
+        "next_eligible_date": next_date,
+        "last_claim_date": last_claim,
+    }
+
 # Add additional helper functions here as required.

--- a/leavebot_copy/scripts/leave_utils.py
+++ b/leavebot_copy/scripts/leave_utils.py
@@ -163,3 +163,36 @@ def leave_codes_summary(leave_history):
     Debug utility: Return a Counter of codes found in leave_history.
     """
     return Counter(rec.get("LeaveGrid_Lvm_Code_V") for rec in leave_history)
+
+
+def recent_leaves(leave_history, count=5):
+    """Return a list of the most recent leave records."""
+
+    def parse_date(date_str):
+        if not date_str:
+            return None
+        for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d", "%d-%b-%Y"):
+            try:
+                return datetime.strptime(date_str[:19], fmt)
+            except Exception:
+                continue
+        return None
+
+    sorted_history = sorted(
+        leave_history,
+        key=lambda rec: parse_date(rec.get("LeaveGrid_Ela_FromDate_D")) or datetime.min,
+        reverse=True,
+    )
+
+    result = []
+    for rec in sorted_history[: int(count)]:
+        result.append(
+            {
+                "code": rec.get("LeaveGrid_Lvm_Code_V"),
+                "description": rec.get("LeaveGrid_Lvm_Description_V"),
+                "from": (rec.get("LeaveGrid_Ela_FromDate_D") or "")[:10],
+                "to": (rec.get("LeaveGrid_Ela_ToDate_D") or "")[:10],
+                "status": rec.get("LeaveGrid_Status"),
+            }
+        )
+    return result

--- a/leavebot_copy/test_api_tools.py
+++ b/leavebot_copy/test_api_tools.py
@@ -4,6 +4,8 @@ from leavebot_copy.scripts.fetch_leave_balance import fetch_leave_balance
 from leavebot_copy.scripts.fetch_leave_history import fetch_leave_history
 from leavebot_copy.scripts.fetch_manager import get_manager_contact   # <--- NEW
 from leavebot_copy.scripts.search_embeddings import search_embeddings
+from leavebot_copy.scripts.leave_utils import recent_leaves
+from leavebot_copy.scripts.air_ticket_utils import air_ticket_info
 
 def pretty_print(title, obj):
     import json
@@ -61,7 +63,27 @@ try:
 except Exception as e:
     print(f"[ERROR] Leave History: {e}")
 
-# 5. Test Document Embedding Search
+# 5. Air Ticket Info
+try:
+    if 'history' in locals() and 'leave_types' in locals():
+        leave_balances = {
+            lt["Lpd_ID_N"]: fetch_leave_balance(EMP_ID, lt["Lpd_ID_N"], FROM_DATE, TO_DATE)
+            for lt in leave_types
+        }
+        ticket = air_ticket_info(leave_balances, history)
+        pretty_print("Air Ticket Info", ticket)
+except Exception as e:
+    print(f"[ERROR] Air Ticket Info: {e}")
+
+# 6. Recent Leaves
+try:
+    if 'history' in locals():
+        recent = recent_leaves(history, count=2)
+        pretty_print("Recent Leaves", recent)
+except Exception as e:
+    print(f"[ERROR] Recent Leaves: {e}")
+
+# 7. Test Document Embedding Search
 try:
     results = search_embeddings("leave policy")
     pretty_print("Embedding Search (leave policy)", results)


### PR DESCRIPTION
## Summary
- add `recent_leaves` helper to leave_utils
- add `air_ticket_info` helper to air_ticket_utils
- expose new tools `recent_leaves` and `air_ticket_info` in the chatbot
- update API test script to demonstrate new helpers

## Testing
- `python3 -m py_compile Leavebot/leavebot_copy/scripts/leave_utils.py Leavebot/leavebot_copy/scripts/air_ticket_utils.py Leavebot/leavebot_copy/chatbot/chat_engine.py Leavebot/leavebot_copy/test_api_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_684abb7af2d08323ad39930b002e5cc9