### PR TITLE
Fix date parsing in air ticket utility

### DIFF
--- a/leavebot_copy/scripts/air_ticket_utils.py
+++ b/leavebot_copy/scripts/air_ticket_utils.py
@@ -20,7 +20,13 @@ def next_air_ticket_eligibility(anniv_date, last_ticket_date=None, period_years=
     """
     if not anniv_date:
         return None
-    anniv = datetime.strptime(anniv_date, "%d-%b-%Y") if '-' in anniv_date else datetime.strptime(anniv_date, "%Y-%m-%d")
+    try:
+        anniv = datetime.strptime(anniv_date, "%d-%b-%Y")
+    except (TypeError, ValueError):
+        try:
+            anniv = datetime.strptime(anniv_date, "%Y-%m-%d")
+        except (TypeError, ValueError):
+            return None
     last = datetime.strptime(last_ticket_date, "%Y-%m-%d") if last_ticket_date else anniv
     return (last + timedelta(days=period_years*365)).strftime("%Y-%m-%d")
 

--- a/leavebot_copy/test_air_ticket_utils.py
+++ b/leavebot_copy/test_air_ticket_utils.py
@@ -1,0 +1,13 @@
+import unittest
+from leavebot_copy.scripts.air_ticket_utils import next_air_ticket_eligibility
+
+class TestAirTicketUtils(unittest.TestCase):
+    def test_next_air_ticket_eligibility_multiple_formats(self):
+        """Both date formats should parse correctly."""
+        d1 = next_air_ticket_eligibility("10-Aug-2023")
+        d2 = next_air_ticket_eligibility("2023-08-10")
+        self.assertEqual(d1, "2025-08-09")
+        self.assertEqual(d1, d2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle multiple anniversary date formats in `next_air_ticket_eligibility`
- add unit test for the supported date formats

## Testing
- `python -m unittest discover -s leavebot_copy -p 'test_*.py'` *(fails: ModuleNotFoundError: No module named 'openai')*
- `python -m unittest leavebot_copy.test_air_ticket_utils -v`

------
https://chatgpt.com/codex/tasks/task_e_684ac024bc9083238de5822ad4b7c55c