### PR TITLE
Improve README usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ python -m leavebot.scripts.test_chatbot_batch <emp_id>
 
 Replace `<emp_id>` with the employee ID you want to test. The script at `leavebot/scripts/test_chatbot_batch.py` resets the chatbot state for that employee, reads questions from `questions.txt`, and prints each question with the bot’s answer. Expect verbose debugging output that shows any tool calls made to fetch API data or search policy documents.
 
+## Running Tests
+
+These tests require a valid `.env` configuration just like the main
+application. Once configured you can execute the scripts directly:
+
+```bash
+python test_air_ticket_utils.py
+python test_api_tools.py
+```
+
+## Interactive Chatbot
+
+With your `.env` configured you can chat with LeaveBot interactively:
+
+```bash
+python -m leavebot.chatbot.chat_engine --emp-id <emp_id>
+```
+
+Additional flags such as `--from-date` and `--to-date` control the
+range of data that is loaded for the session.
+
 ## Dependencies
 
 The project relies on several internal API endpoints for employee data. These URLs and an authentication token (`ERP_BEARER_TOKEN`) must be supplied via environment variables. In addition, an `OPENAI_API_KEY` is required for both chat completion and embedding search features.


### PR DESCRIPTION
## Summary
- document how to run test_air_ticket_utils.py and test_api_tools.py
- add instructions for launching the interactive chatbot

## Testing
- `python test_air_ticket_utils.py`
- `python test_api_tools.py` *(fails: connection refused / missing API key)*

------
https://chatgpt.com/codex/tasks/task_e_684ae0551c74832388bb9c2feead6a06