### PR TITLE
Fix quotes and newline in questions

### DIFF
--- a/questions.txt
+++ b/questions.txt
@@ -1,19 +1,19 @@
-“What is my air ticket eligibility status?”
+"What is my air ticket eligibility status?"
 
-“When can I next claim an air ticket?”
+"When can I next claim an air ticket?"
 
-“Show me my most recent leave applications.”
+"Show me my most recent leave applications."
 
-“Give me the last two leaves I applied for.”
+"Give me the last two leaves I applied for."
 
-“List my latest three leave requests with their dates.”
+"List my latest three leave requests with their dates."
 
-“Have I claimed an air ticket in the past year?”
+"Have I claimed an air ticket in the past year?"
 
-“What percent of my ticket fare am I eligible for?”
+"What percent of my ticket fare am I eligible for?"
 
-“When did I last apply for leave?”
+"When did I last apply for leave?"
 
-“Tell me about my most recent sick or casual leaves.” (returns recent leaves of any type)
+"Tell me about my most recent sick or casual leaves." (returns recent leaves of any type)
 
-“What was my last approved leave?”
+"What was my last approved leave?"


### PR DESCRIPTION
## Summary
- convert curly quotes in `questions.txt` to normal quotes
- add a final newline to `questions.txt`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae058a8fc8323b2873f236687db0d