### PR TITLE
Refactor chat engine into class

### DIFF
--- a/leavebot/chatbot/chat_engine.py
+++ b/leavebot/chatbot/chat_engine.py
@@ -29,94 +29,196 @@ from ..scripts.air_ticket_utils import air_ticket_info
 # Setup OpenAI API key
 openai.api_key = os.getenv("OPENAI_API_KEY", "")
 
-# Globals populated by preload_data()
-employee = None
-leave_types = None
-leave_history = None
-leave_balances = None
-manager = None
+class ChatEngine:
+    """Encapsulates chatbot state and interactions."""
 
+    def __init__(self):
+        self.employee = None
+        self.leave_types = None
+        self.leave_history = None
+        self.leave_balances = None
+        self.manager = None
+        self.TOOL_MAP = {
+            "total_leave_taken": self.tool_total_leave_taken,
+            "leaves_by_type": self.tool_leaves_by_type,
+            "available_leave_types": self.tool_available_leave_types,
+            "leave_type_balance": self.tool_leave_type_balance,
+            "years_of_service": self.tool_years_of_service,
+            "employee_contact": self.tool_employee_contact,
+            "manager_contact": self.tool_manager_contact,
+            "is_on_leave_today": self.tool_is_on_leave_today,
+            "recent_leaves": self.tool_recent_leaves,
+            "air_ticket_info": self.tool_air_ticket_info,
+            "search_policy": self.tool_search_policy,
+        }
 
-def preload_data(emp_id, from_date, to_date, cgm_id=1):
-    """Fetch and cache employee-related data for the session."""
-    employee = fetch_employee_details(emp_id)
-    leave_types = fetch_leave_types(emp_id, cgm_id)
-    leave_history = fetch_leave_history(emp_id, leave_types)
-    leave_balances = {
-        lt["Lpd_ID_N"]: fetch_leave_balance(emp_id, lt["Lpd_ID_N"], from_date, to_date)
-        for lt in leave_types
-    }
-    manager = get_manager_details(employee, fetch_employee_details)
-    return employee, leave_types, leave_history, leave_balances, manager
+    # --- DATA PRELOAD ---
+    def preload_data(self, emp_id, from_date, to_date, cgm_id=1):
+        """Fetch and cache employee-related data for the session."""
+        self.employee = fetch_employee_details(emp_id)
+        self.leave_types = fetch_leave_types(emp_id, cgm_id)
+        self.leave_history = fetch_leave_history(emp_id, self.leave_types)
+        self.leave_balances = {
+            lt["Lpd_ID_N"]: fetch_leave_balance(emp_id, lt["Lpd_ID_N"], from_date, to_date)
+            for lt in self.leave_types
+        }
+        self.manager = get_manager_details(self.employee, fetch_employee_details)
+        return (
+            self.employee,
+            self.leave_types,
+            self.leave_history,
+            self.leave_balances,
+            self.manager,
+        )
 
-# --- TOOL DEFINITIONS ---
+    # --- TOOL DEFINITIONS ---
+    def tool_total_leave_taken(self, leave_code=None, **kwargs):
+        """Returns total leave days taken, optionally filtered by code or group."""
+        return total_leave_taken(self.leave_history, self.leave_types, code_or_group=leave_code)
 
-def tool_total_leave_taken(leave_code=None, **kwargs):
-    """Returns total leave days taken, optionally filtered by code or group."""
-    return total_leave_taken(leave_history, leave_types, code_or_group=leave_code)
+    def tool_leaves_by_type(self, **kwargs):
+        """Returns dict of leave codes with days taken for each."""
+        return leaves_by_type(self.leave_history, self.leave_types)
 
-def tool_leaves_by_type(**kwargs):
-    """Returns dict of leave codes with days taken for each."""
-    return leaves_by_type(leave_history, leave_types)
+    def tool_available_leave_types(self, **kwargs):
+        """Lists all leave types available for the employee."""
+        return available_leave_types(self.leave_types)
 
-def tool_available_leave_types(**kwargs):
-    """Lists all leave types available for the employee."""
-    return available_leave_types(leave_types)
+    def tool_leave_type_balance(self, leave_code=None, **kwargs):
+        """Returns balance for a specific leave code or description."""
+        if leave_code is None:
+            return None
+        return leave_type_balance(self.leave_balances, self.leave_types, code_or_desc=leave_code)
 
-def tool_leave_type_balance(leave_code=None, **kwargs):
-    """Returns balance for a specific leave code or description."""
-    if leave_code is None:
-        return None
-    return leave_type_balance(leave_balances, leave_types, code_or_desc=leave_code)
+    def tool_years_of_service(self, **kwargs):
+        """Returns number of years the employee has been with the company."""
+        return years_of_service(self.employee)
 
-def tool_years_of_service(**kwargs):
-    """Returns number of years the employee has been with the company."""
-    return years_of_service(employee)
+    def tool_employee_contact(self, **kwargs):
+        """Returns the contact summary for the employee."""
+        return employee_contact_summary(self.employee)
 
-def tool_employee_contact(**kwargs):
-    """Returns the contact summary for the employee."""
-    return employee_contact_summary(employee)
+    def tool_manager_contact(self, **kwargs):
+        """Returns the manager's contact information."""
+        return self.manager
 
-def tool_manager_contact(**kwargs):
-    """Returns the manager's contact information."""
-    return manager
+    def tool_is_on_leave_today(self, **kwargs):
+        """Returns whether the employee is on leave today."""
+        return is_on_leave_today(self.leave_history)
 
-def tool_is_on_leave_today(**kwargs):
-    """Returns whether the employee is on leave today."""
-    return is_on_leave_today(leave_history)
+    def tool_recent_leaves(self, count=5, **kwargs):
+        """Returns the most recent leave applications."""
+        return recent_leaves(self.leave_history, count=count)
 
-def tool_recent_leaves(count=5, **kwargs):
-    """Returns the most recent leave applications."""
-    return recent_leaves(leave_history, count=count)
+    def tool_air_ticket_info(self, **kwargs):
+        """Returns air ticket eligibility information."""
+        return air_ticket_info(self.leave_balances, self.leave_history)
 
-def tool_air_ticket_info(**kwargs):
-    """Returns air ticket eligibility information."""
-    return air_ticket_info(leave_balances, leave_history)
+    def tool_search_policy(self, question=None, **kwargs):
+        """Search HR policy docs for answers to policy questions."""
+        results = search_embeddings(question, top_k=2)
+        if not results:
+            return "No relevant policy or HR information found."
+        answer = ""
+        for idx, chunk in enumerate(results, 1):
+            answer += f"{idx}. {chunk['chunk'].strip()}\n\n"
+        return answer.strip()
 
-def tool_search_policy(question=None, **kwargs):
-    """Search HR policy docs for answers to policy questions."""
-    results = search_embeddings(question, top_k=2)
-    if not results:
-        return "No relevant policy or HR information found."
-    answer = ""
-    for idx, chunk in enumerate(results, 1):
-        answer += f"{idx}. {chunk['chunk'].strip()}\n\n"
-    return answer.strip()
+    # ---- TOOL ROUTER ----
+    def route_tool(self, tool_name, args=None):
+        if tool_name not in self.TOOL_MAP:
+            return "Tool not implemented."
+        return self.TOOL_MAP[tool_name](**(args or {}))
 
-# --- TOOL MAP ---
-TOOL_MAP = {
-    "total_leave_taken":   tool_total_leave_taken,
-    "leaves_by_type":      tool_leaves_by_type,
-    "available_leave_types": tool_available_leave_types,
-    "leave_type_balance":  tool_leave_type_balance,
-    "years_of_service":    tool_years_of_service,
-    "employee_contact":    tool_employee_contact,
-    "manager_contact":     tool_manager_contact,
-    "is_on_leave_today":   tool_is_on_leave_today,
-    "recent_leaves":       tool_recent_leaves,
-    "air_ticket_info":     tool_air_ticket_info,
-    "search_policy":       tool_search_policy,
-}
+    # ---- CHATBOT LOOP (WITH MULTI-STEP TOOL CALLING SUPPORT) ----
+    def stream_completion(self, messages):
+        """Stream the assistant's reply and return the full text."""
+        response = openai.chat.completions.create(
+            model=os.getenv("OPENAI_MODEL", "gpt-4o"),
+            messages=messages,
+            tools=tools,
+            max_tokens=512,
+            stream=True,
+        )
+        full = ""
+        for chunk in response:
+            delta = chunk.choices[0].delta
+            if delta.content:
+                print(delta.content, end="", flush=True)
+                full += delta.content
+        print()
+        return full
+
+    def run_chat(self, emp_id=5469, from_date="2024-01-01", to_date="2024-12-31", history_length=20):
+        self.preload_data(emp_id, from_date, to_date)
+
+        print("LeaveBot: Ask your question (type 'exit' to quit):")
+        messages = [{
+            "role": "system",
+            "content": (
+                "You are LeaveBot, a helpful HR and policy assistant. "
+                "If a user asks a question not directly answerable by API or calculations, use the search_policy tool."
+            ),
+        }]
+
+        while True:
+            user_input = input("User: ")
+            if user_input.strip().lower() == "exit":
+                break
+
+            messages.append({"role": "user", "content": user_input})
+            try:
+                response = openai.chat.completions.create(
+                    model=os.getenv("OPENAI_MODEL", "gpt-4o"),
+                    messages=messages,
+                    tools=tools,
+                    tool_choice="auto",
+                    max_tokens=512,
+                )
+            except openai.AuthenticationError:
+                print(
+                    "OpenAI authentication failed. Please set the OPENAI_API_KEY environment variable with a valid API key."
+                )
+                return
+
+            msg = response.choices[0].message
+
+            # Handle any function calls
+            while hasattr(msg, "tool_calls") and msg.tool_calls:
+                messages.append({
+                    "role": "assistant",
+                    "tool_calls": [c.model_dump() for c in msg.tool_calls],
+                })
+                for call in msg.tool_calls:
+                    name = call.function.name
+                    args = json.loads(call.function.arguments) if call.function.arguments else {}
+                    result = self.route_tool(name, args)
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": call.id,
+                        "name": name,
+                        "content": str(result),
+                    })
+                try:
+                    response = openai.chat.completions.create(
+                        model=os.getenv("OPENAI_MODEL", "gpt-4o"),
+                        messages=messages,
+                        tools=tools,
+                        max_tokens=512,
+                    )
+                except openai.AuthenticationError:
+                    print(
+                        "OpenAI authentication failed. Please set the OPENAI_API_KEY environment variable with a valid API key."
+                    )
+                    return
+                msg = response.choices[0].message
+
+            final_text = self.stream_completion(messages)
+            messages.append({"role": "assistant", "content": final_text})
+
+            if history_length:
+                messages = [messages[0]] + messages[-history_length:]
+
 
 # --- TOOL SCHEMA ---
 tools = [
@@ -232,106 +334,10 @@ tools = [
     },
 ]
 
-# ---- TOOL ROUTER ----
-def route_tool(tool_name, args=None):
-    if tool_name not in TOOL_MAP:
-        return "Tool not implemented."
-    return TOOL_MAP[tool_name](**(args or {}))
-
-# ---- CHATBOT LOOP (WITH MULTI-STEP TOOL CALLING SUPPORT) ----
-def stream_completion(messages):
-    """Stream the assistant's reply and return the full text."""
-    response = openai.chat.completions.create(
-        model=os.getenv("OPENAI_MODEL", "gpt-4o"),
-        messages=messages,
-        tools=tools,
-        max_tokens=512,
-        stream=True,
-    )
-    full = ""
-    for chunk in response:
-        delta = chunk.choices[0].delta
-        if delta.content:
-            print(delta.content, end="", flush=True)
-            full += delta.content
-    print()
-    return full
-
 
 def run_chat(emp_id=5469, from_date="2024-01-01", to_date="2024-12-31", history_length=20):
-    global employee, leave_types, leave_history, leave_balances, manager
-
-    employee, leave_types, leave_history, leave_balances, manager = preload_data(
-        emp_id, from_date, to_date
-    )
-
-    print("LeaveBot: Ask your question (type 'exit' to quit):")
-    messages = [{
-        "role": "system",
-        "content": (
-            "You are LeaveBot, a helpful HR and policy assistant. "
-            "If a user asks a question not directly answerable by API or calculations, use the search_policy tool."
-        ),
-    }]
-
-    while True:
-        user_input = input("User: ")
-        if user_input.strip().lower() == "exit":
-            break
-
-        messages.append({"role": "user", "content": user_input})
-        try:
-            response = openai.chat.completions.create(
-                model=os.getenv("OPENAI_MODEL", "gpt-4o"),
-                messages=messages,
-                tools=tools,
-                tool_choice="auto",
-                max_tokens=512,
-            )
-        except openai.AuthenticationError:
-            print(
-                "OpenAI authentication failed. Please set the OPENAI_API_KEY environment variable with a valid API key."
-            )
-            return
-
-        msg = response.choices[0].message
-
-        # Handle any function calls
-        while hasattr(msg, "tool_calls") and msg.tool_calls:
-            messages.append({
-                "role": "assistant",
-                "tool_calls": [c.model_dump() for c in msg.tool_calls],
-            })
-            for call in msg.tool_calls:
-                name = call.function.name
-                args = json.loads(call.function.arguments) if call.function.arguments else {}
-                result = route_tool(name, args)
-                messages.append({
-                    "role": "tool",
-                    "tool_call_id": call.id,
-                    "name": name,
-                    "content": str(result),
-                })
-            try:
-                response = openai.chat.completions.create(
-                    model=os.getenv("OPENAI_MODEL", "gpt-4o"),
-                    messages=messages,
-                    tools=tools,
-                    max_tokens=512,
-                )
-            except openai.AuthenticationError:
-                print(
-                    "OpenAI authentication failed. Please set the OPENAI_API_KEY environment variable with a valid API key."
-                )
-                return
-            msg = response.choices[0].message
-
-        # Stream the final assistant message
-        final_text = stream_completion(messages)
-        messages.append({"role": "assistant", "content": final_text})
-
-        if history_length:
-            messages = [messages[0]] + messages[-history_length:]
+    """Convenience wrapper that runs the chat with a fresh ChatEngine."""
+    ChatEngine().run_chat(emp_id, from_date, to_date, history_length)
 
 
 if __name__ == "__main__":

--- a/leavebot/scripts/test_chatbot_batch.py
+++ b/leavebot/scripts/test_chatbot_batch.py
@@ -11,6 +11,8 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from ..chatbot import chat_engine
+
+ChatEngine = chat_engine.ChatEngine
 from ..config.settings import DOC_EMBEDDINGS_PATH
 
 QUESTIONS_FILE = os.path.join(REPO_ROOT, 'questions.txt')
@@ -23,17 +25,8 @@ def run_batch_test(
     to_date="2024-12-31",
 ):
     """Run a batch of questions against the chatbot."""
-    # Reset chatbot state for each test session
-    chat_engine.EMP_ID = emp_id
-
-    # Preload and cache all employee data
-    (
-        chat_engine.employee,
-        chat_engine.leave_types,
-        chat_engine.leave_history,
-        chat_engine.leave_balances,
-        chat_engine.manager,
-    ) = chat_engine.preload_data(emp_id, from_date, to_date, cgm_id)
+    engine = ChatEngine()
+    engine.preload_data(emp_id, from_date, to_date, cgm_id)
 
     # Read questions
     with open(questions_file, 'r', encoding='utf-8') as f:
@@ -82,7 +75,7 @@ def run_batch_test(
                 tool_name = call.function.name
                 args_json = call.function.arguments
                 args_dict = json.loads(args_json) if args_json else {}
-                tool_response = chat_engine.route_tool(tool_name, args_dict)
+                tool_response = engine.route_tool(tool_name, args_dict)
                 messages.append({
                     "role": "tool",
                     "tool_call_id": call.id,


### PR DESCRIPTION
## Summary
- refactor `chat_engine` globals into `ChatEngine` class
- expose a `run_chat` wrapper using the new class
- update `test_chatbot_batch` to instantiate the chat engine

## Testing
- `python test_air_ticket_utils.py`
- `python test_api_tools.py` *(fails: connection refused / missing API key)*

------
https://chatgpt.com/codex/tasks/task_e_684ae333ca0c83239902554a52496864