### PR TITLE
Centralize OpenAI key setup

### DIFF
--- a/leavebot/chatbot/chat_engine.py
+++ b/leavebot/chatbot/chat_engine.py
@@ -1,3 +1,4 @@
+from ..config import settings
 import openai
 import os
 import json
@@ -26,8 +27,7 @@ from ..scripts.search_embeddings import search_embeddings  # RAG tool
 from ..scripts.air_ticket_utils import air_ticket_info
 
 
-# Setup OpenAI API key
-openai.api_key = os.getenv("OPENAI_API_KEY", "")
+# OpenAI key is configured in settings when the module is imported above
 
 # Globals populated by preload_data()
 employee = None

--- a/leavebot/config/settings.py
+++ b/leavebot/config/settings.py
@@ -1,4 +1,5 @@
 import os
+import openai
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -9,6 +10,7 @@ LEAVE_HISTORY_API = os.getenv("LEAVE_HISTORY_API", "http://localhost/api/LeaveAp
 LEAVE_SUMMARY_API = os.getenv("LEAVE_SUMMARY_API", "http://localhost/api/LeaveApplicationApi")
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+openai.api_key = OPENAI_API_KEY
 ERP_BEARER_TOKEN = os.getenv("ERP_BEARER_TOKEN", "")
 
 RAW_DATA_PATH = os.path.join("data", "raw")

--- a/leavebot/scripts/search_embeddings.py
+++ b/leavebot/scripts/search_embeddings.py
@@ -1,10 +1,10 @@
 import os
 import json
 import numpy as np
+from leavebot.config import settings
 import openai
-from leavebot.config.settings import DOC_EMBEDDINGS_PATH
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
+DOC_EMBEDDINGS_PATH = settings.DOC_EMBEDDINGS_PATH
 
 def get_query_embedding(query, model="text-embedding-3-large"):
     # Or "text-embedding-ada-002" for legacy


### PR DESCRIPTION
## Summary
- initialize `openai.api_key` in `settings.py`
- rely on settings to configure OpenAI in `chat_engine` and `search_embeddings`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae334cb4083239f383518efda1d7f